### PR TITLE
Quick spelling fix

### DIFF
--- a/war/src/main/resources/plugin.yml
+++ b/war/src/main/resources/plugin.yml
@@ -147,7 +147,7 @@ commands:
         /setbomb <bomb-name>
   setcake:
     description: War> Creates or moves a cake. Get the cake to your spawn to score a replenish your lifepool. 
-    usage: Creates or moves a bomb. Get the cake to your spawn to score a replenish your lifepool. Must be standing in warzone.
+    usage: Creates or moves a cake. Get the cake to your spawn to score a replenish your lifepool. Must be standing in warzone.
         Ex -
         /setcake <cake-name>   
   resetzone:


### PR DESCRIPTION
In the usage message for /setcake, it says 'Creates or moves a bomb'. It was bugging me so I decided to fix it.
