### PR TITLE
Fixed a missing RIGHT_CLICK_AIR action.

### DIFF
--- a/war/src/main/java/com/tommytony/war/event/WarPlayerListener.java
+++ b/war/src/main/java/com/tommytony/war/event/WarPlayerListener.java
@@ -210,7 +210,7 @@ public class WarPlayerListener implements Listener {
 			if (player.getItemInHand().getType() == Material.WOOD_SWORD && War.war.isWandBearer(player)) {
 				String zoneName = War.war.getWandBearerZone(player);
 				ZoneSetter setter = new ZoneSetter(player, zoneName);
-				if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_AIR) {
+				if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_AIR) {
 					War.war.badMsg(player, "Too far.");
 				} else if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
 					setter.placeCorner1(event.getClickedBlock());


### PR DESCRIPTION
I just started reading through your plugin to get a sense of how it's written and I noticed an OR conditional with the same test on both sides.  It seems like you want to test for `Action.RIGHT_CLICK_AIR` and print out a message when the player is using the wand for zone creation.
