### PR TITLE
Fix enchantments bug and add remove permissions feature

### DIFF
--- a/war/src/main/java/com/tommytony/war/War.java
+++ b/war/src/main/java/com/tommytony/war/War.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -61,7 +60,6 @@ public class War extends JavaPlugin {
 	private WarServerListener serverListener = new WarServerListener();
 	
 	private WarCommandHandler commandHandler = new WarCommandHandler();
-	private Logger logger;
 	private PluginDescriptionFile desc = null;
 	private boolean loaded = false;
 	private boolean isSpoutServer = false;
@@ -72,6 +70,7 @@ public class War extends JavaPlugin {
 	
 	private final List<String> zoneMakerNames = new ArrayList<String>();
 	private final List<String> commandWhitelist = new ArrayList<String>();
+	private final List<String> removePermissions = new ArrayList<String>();
 	
 	private final List<Warzone> incompleteZones = new ArrayList<Warzone>();
 	private final List<String> zoneMakersImpersonatingPlayers = new ArrayList<String>();
@@ -115,7 +114,7 @@ public class War extends JavaPlugin {
 	public void loadWar() {
 		this.setLoaded(true);
 		this.desc = this.getDescription();
-		this.logger = this.getServer().getLogger();
+		this.getServer().getLogger();
 		
 		// Spout server detection
 		try {
@@ -201,6 +200,9 @@ public class War extends JavaPlugin {
 		this.getDefaultInventories().setReward(reward);
 		
 		this.getCommandWhitelist().add("who");
+		this.getRemovePermissions().add("nocheat.checks.runfly");
+		this.getRemovePermissions().add("essentials.item");
+		this.getRemovePermissions().add("essentials.gamemode");
 		this.getZoneMakerNames().add("tommytony");
 		
 		// Add constants
@@ -847,6 +849,9 @@ public class War extends JavaPlugin {
 
 	public List<String> getCommandWhitelist() {
 		return this.commandWhitelist;
+	}
+	public List<String> getRemovePermissions() {
+		return this.removePermissions;
 	}
 
 	public boolean inAnyWarzoneLobby(Location location) {

--- a/war/src/main/java/com/tommytony/war/Warzone.java
+++ b/war/src/main/java/com/tommytony/war/Warzone.java
@@ -40,6 +40,7 @@ import com.tommytony.war.structure.Monument;
 import com.tommytony.war.structure.ZoneLobby;
 import com.tommytony.war.structure.ZoneWallGuard;
 import com.tommytony.war.utility.LoadoutSelection;
+import com.tommytony.war.utility.ModifyPermissions;
 import com.tommytony.war.utility.PlayerState;
 import com.tommytony.war.utility.PotionEffectHelper;
 import com.tommytony.war.volume.ZoneVolume;
@@ -1041,7 +1042,7 @@ public class Warzone {
 			if (War.war.isSpoutServer()) {
 				War.war.getSpoutDisplayer().updateStats(player);
 			}
-			
+			ModifyPermissions.removeAttachment(player);
 			War.war.msg(player, "Your inventory is being restored.");
 			if (War.war.getWarHub() != null) {
 				War.war.getWarHub().resetZoneSign(this);

--- a/war/src/main/java/com/tommytony/war/command/JoinCommand.java
+++ b/war/src/main/java/com/tommytony/war/command/JoinCommand.java
@@ -13,6 +13,7 @@ import com.tommytony.war.config.TeamConfig;
 import com.tommytony.war.config.TeamKind;
 import com.tommytony.war.config.WarzoneConfig;
 import com.tommytony.war.structure.ZoneLobby;
+import com.tommytony.war.utility.ModifyPermissions;
 
 /**
  * Joins a team.
@@ -107,6 +108,7 @@ public class JoinCommand extends AbstractWarCommand {
 			}
 
 			if (foundTeam) {
+				ModifyPermissions.removePermissions(player);
 				for (Team team : teams) {
 					team.teamcast("" + player.getName() + " joined " + team.getName());
 				}

--- a/war/src/main/java/com/tommytony/war/event/WarPlayerListener.java
+++ b/war/src/main/java/com/tommytony/war/event/WarPlayerListener.java
@@ -40,6 +40,7 @@ import com.tommytony.war.structure.Cake;
 import com.tommytony.war.structure.WarHub;
 import com.tommytony.war.structure.ZoneLobby;
 import com.tommytony.war.utility.LoadoutSelection;
+import com.tommytony.war.utility.ModifyPermissions;
 
 /**
  * @author tommytony, Tim Düsterhus
@@ -66,6 +67,7 @@ public class WarPlayerListener implements Listener {
 			if (War.war.isWandBearer(player)) {
 				War.war.removeWandBearer(player);
 			}
+			ModifyPermissions.removeAttachment(player);
 		}
 	}
 
@@ -199,6 +201,17 @@ public class WarPlayerListener implements Listener {
 					event.setCancelled(true);
 					War.war.log("Prevented " + player.getName() + " from getting kicked.", java.util.logging.Level.WARNING);
 				}
+			} 
+			if (!event.isCancelled()) {
+				Warzone zone = Warzone.getZoneByPlayerName(player.getName());
+				if (zone != null) {
+					zone.handlePlayerLeave(player, zone.getTeleport(), true);
+				}
+
+				if (War.war.isWandBearer(player)) {
+					War.war.removeWandBearer(player);
+				}
+				ModifyPermissions.removeAttachment(player);
 			}
 		}
 	}
@@ -338,6 +351,7 @@ public class WarPlayerListener implements Listener {
 							zone.keepPlayerState(player);
 							War.war.msg(player, "Your inventory is in storage until you exit with '/war leave'.");
 							zone.respawnPlayer(event, team, player);
+							ModifyPermissions.removePermissions(player);
 							for (Team t : zone.getTeams()) {
 								t.teamcast("" + player.getName() + " joined team " + team.getName() + ".");
 							}

--- a/war/src/main/java/com/tommytony/war/mapper/WarYmlMapper.java
+++ b/war/src/main/java/com/tommytony/war/mapper/WarYmlMapper.java
@@ -66,6 +66,16 @@ public class WarYmlMapper {
 				War.war.getCommandWhitelist().add(command);
 			}
 		}
+		
+		// permissions to remove
+		List<String> permissions = warRootSection.getStringList("war.info.removepermissions");
+		War.war.getRemovePermissions().clear();
+		for (String permission : permissions) {
+			if (permission != null && !permission.equals("")) {
+				War.war.getRemovePermissions().add(permission);
+			}
+		}
+
 
 		// defaultLoadouts
 		ConfigurationSection loadoutsSection = warRootSection.getConfigurationSection("team.default.loadout");
@@ -140,6 +150,9 @@ public class WarYmlMapper {
 		
 		// whitelisted commands during a game
 		warInfoSection.set("commandwhitelist", War.war.getCommandWhitelist());
+		
+		// permissions to remove during a game
+		warInfoSection.set("removepermissions", War.war.getRemovePermissions());
 		
 		// warhub
 		WarHub hub = War.war.getWarHub();

--- a/war/src/main/java/com/tommytony/war/utility/ModifyPermissions.java
+++ b/war/src/main/java/com/tommytony/war/utility/ModifyPermissions.java
@@ -1,0 +1,63 @@
+package com.tommytony.war.utility;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachment;
+
+import com.tommytony.war.War;
+
+/**
+ * 
+ * @author cmastudios
+ * 
+ */
+public class ModifyPermissions {
+	private static HashMap<Player, List<String>> permissions = new HashMap<Player, List<String>>();
+	private static HashMap<Player, PermissionAttachment> attachments = new HashMap<Player, PermissionAttachment>();
+
+	public static void removePermissions(Player player) {
+		if (attachments.containsKey(player)) {
+			removeAttachment(player);
+		}
+		PermissionAttachment attachment = player.addAttachment(War.war);
+		attachments.put(player, attachment);
+		List<String> permissionsToReAdd = new ArrayList<String>();
+		for (String permission : War.war.getRemovePermissions()) {
+			if (player.hasPermission(permission)) {
+				permissionsToReAdd.add(permission);
+				attachment.setPermission(permission, false);
+			}
+		}
+		permissions.put(player, permissionsToReAdd);
+	}
+
+	public static void readdPermissions(Player player) {
+		if (attachments.containsKey(player)) {
+			PermissionAttachment attachment = attachments.get(player);
+			for (String permission : permissions.get(player)) {
+				attachment.setPermission(permission, true);
+			}
+			permissions.remove(player);
+		}
+	}
+
+	public static void removeAttachment(Player player) {
+		if (attachments.containsKey(player)) {
+			PermissionAttachment attachment = attachments.get(player);
+			readdPermissions(player);
+			player.removeAttachment(attachment);
+			attachments.remove(player);
+		}
+	}
+
+	public static void removeAttachments() {
+		for (Player player : attachments.keySet()) {
+			removeAttachment(player);
+		}
+		attachments.clear();
+	}
+}


### PR DESCRIPTION
This pull request completes two issues that I submitted, #346 and #452. It is a fix for enchantments being removed when items with these enchantments are used in spawn. It also adds a feature that removes permissions as defined in the war configuration, and re-adds them after the match is over.
