### PR TITLE
Add team-based permission requirement

### DIFF
--- a/war/src/main/java/com/tommytony/war/War.java
+++ b/war/src/main/java/com/tommytony/war/War.java
@@ -184,6 +184,7 @@ public class War extends JavaPlugin {
 		teamDefaultConfig.put(TeamConfig.SATURATION, 10);
 		teamDefaultConfig.put(TeamConfig.SPAWNSTYLE, TeamSpawnStyle.SMALL);
 		teamDefaultConfig.put(TeamConfig.TEAMSIZE, 10);
+		teamDefaultConfig.put(TeamConfig.PERMISSION, "war.player");
 		
 		this.getDefaultInventories().getLoadouts().clear();
 		HashMap<Integer, ItemStack> defaultLoadout = new HashMap<Integer, ItemStack>();
@@ -937,15 +938,16 @@ public class War extends JavaPlugin {
 		}
 		return null;
 	}
-
+        
 	/**
-	 * Checks whether the given player is allowed to play war.
+	 * Checks whether the given player is allowed to play in a certain team
 	 *
 	 * @param 	player	Player to check
-	 * @return		true if the player may play war
+         * @param         team  Team to check  
+	 * @return		true if the player may play in the team
 	 */
-	public boolean canPlayWar(Player player) {
-		return player.hasPermission("war.player");
+	public boolean canPlayWar(Player player, Team team) {
+		return player.hasPermission(team.getTeamConfig().resolveString(TeamConfig.PERMISSION));
 	}
 
 	/**

--- a/war/src/main/java/com/tommytony/war/Warzone.java
+++ b/war/src/main/java/com/tommytony/war/Warzone.java
@@ -830,7 +830,9 @@ public class Warzone {
 		Team lowestNoOfPlayers = null;
 		for (Team t : this.teams) {
 			if (lowestNoOfPlayers == null || (lowestNoOfPlayers != null && lowestNoOfPlayers.getPlayers().size() > t.getPlayers().size())) {
-				lowestNoOfPlayers = t;
+                                if (War.war.canPlayWar(player, t)) {
+                                        lowestNoOfPlayers = t;
+                                }
 			}
 		}
 		if (lowestNoOfPlayers != null) {

--- a/war/src/main/java/com/tommytony/war/command/JoinCommand.java
+++ b/war/src/main/java/com/tommytony/war/command/JoinCommand.java
@@ -32,10 +32,6 @@ public class JoinCommand extends AbstractWarCommand {
 		}
 
 		Player player = (Player) this.getSender();
-		if (!War.war.canPlayWar(player)) {
-			this.badMsg("Cannot play war. You need the war.player permission.");
-			return true;
-		}
 
 		Warzone zone;
 		if (this.args.length == 0) {
@@ -87,6 +83,10 @@ public class JoinCommand extends AbstractWarCommand {
 			boolean foundTeam = false;
 			for (Team team : teams) {
 				if (team.getName().startsWith(name) || team.getKind() == kind) {
+                                        if (!War.war.canPlayWar(player, team)) {
+                                                this.badMsg("You don't have permission to join this team.");
+                                                return true;
+                                        }
 					if (!zone.hasPlayerState(player.getName())) {
 						zone.keepPlayerState(player);
 						this.msg("Your inventory is in storage until you use '/war leave'.");

--- a/war/src/main/java/com/tommytony/war/config/TeamConfig.java
+++ b/war/src/main/java/com/tommytony/war/config/TeamConfig.java
@@ -12,7 +12,8 @@ public enum TeamConfig {
 	RESPAWNTIMER (Integer.class),
 	SATURATION (Integer.class),
 	SPAWNSTYLE (TeamSpawnStyle.class),
-	TEAMSIZE (Integer.class);
+	TEAMSIZE (Integer.class),
+        PERMISSION (String.class);
 	
 	private final Class<?> configType;
 

--- a/war/src/main/java/com/tommytony/war/config/TeamConfigBag.java
+++ b/war/src/main/java/com/tommytony/war/config/TeamConfigBag.java
@@ -92,6 +92,25 @@ public class TeamConfigBag {
 		}
 	}
 	
+	public String getString(TeamConfig config) {
+		if (this.contains(config)) {
+			return (String)this.bag.get(config);
+		}
+		return null;
+	}
+	
+	public String resolveString(TeamConfig config) {
+		if (this.contains(config)) {
+			return (String)this.bag.get(config); 
+		} else if (this.warzone != null && this.warzone.getTeamDefaultConfig().contains(config)){
+			// use Warzone default config
+			return this.warzone.getTeamDefaultConfig().resolveString(config);
+		} else {
+			// use War default config
+			return War.war.getTeamDefaultConfig().resolveString(config);
+		}
+	}
+	
 	public FlagReturn resolveFlagReturn() {
 		if (this.contains(TeamConfig.FLAGRETURN)) {
 			return (FlagReturn)this.bag.get(TeamConfig.FLAGRETURN); 
@@ -136,6 +155,8 @@ public class TeamConfigBag {
 					this.put(config, teamConfigSection.getInt(config.toString()));
 				} else if (config.getConfigType().equals(Boolean.class)) {
 					this.put(config, teamConfigSection.getBoolean(config.toString()));
+				} else if (config.getConfigType().equals(String.class)) {
+					this.put(config, teamConfigSection.getString(config.toString()));
 				} else if (config.getConfigType().equals(FlagReturn.class)) {
 					String flagReturnStr = teamConfigSection.getString(config.toString());
 					FlagReturn returnMode = FlagReturn.getFromString(flagReturnStr);
@@ -177,6 +198,9 @@ public class TeamConfigBag {
 				} else if (teamConfig.getConfigType().equals(Boolean.class)) {
 					String onOff = namedParams.get(namedParam);
 					this.bag.put(teamConfig, onOff.equals("on") || onOff.equals("true"));
+				} else if (teamConfig.getConfigType().equals(String.class)) {
+					String str = namedParams.get(namedParam);
+					this.bag.put(teamConfig, str);
 				} else if (teamConfig.getConfigType().equals(FlagReturn.class)) {
 					FlagReturn flagValue = FlagReturn.getFromString(namedParams.get(namedParam));
 					this.bag.put(teamConfig, flagValue);


### PR DESCRIPTION
Created by request of Zacraft210 on the Warhub server. 
This adds a team default permission configuration option. Default is war.player. It is modifiable at the zone level and the team level.
You could use this for example to make a mob fighting zone. The team for admins who would be spawning mobs would require a permission only admins had to be able to join it.
This could also be used to restrict a zone to a certain rank only and not allow higher ranked players in. The permission for the zone could be set to say, zone.bootcamp. The rank that you want to allow in could be granted that permission, and then other ranks and up (via permissions plugin group inheritance) could have that permission set to false so they could not join. Admins could be granted the permission to allow them to moderate the zone
