### PR TITLE
Fixed inability to download spout from maven

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -8,6 +8,10 @@
 
   <name>War</name>
   <url>http://war.tommytony.com</url>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <repositories>
         <repository>
             <id>bukkit-repo</id>
@@ -15,7 +19,7 @@
         </repository>
         <repository>
             <id>spout-repo</id>
-            <url>http://nexus.spout.org/content/groups/public/</url>
+            <url>http://repo.spout.org/</url>
         </repository>
     </repositories>
   <issueManagement>
@@ -55,9 +59,10 @@
   <dependencies>
     <dependency>
       <groupId>org.getspout</groupId>
-      <artifactId>spoutpluginapi</artifactId>
-      <version>dev-SNAPSHOT</version>
+      <artifactId>spoutplugin</artifactId>
+      <version>1.4.6-R0.2-SNAPSHOT</version>
       <scope>compile</scope>
+      <type>jar</type>
     </dependency>
     <dependency>
 	<groupId>junit</groupId>


### PR DESCRIPTION
Spout changed the format of their repository again. @tommytony probably didn't notice because it was cached in his local maven repository.
This needs to be pulled in now as it is preventing building.
