### PR TITLE
Add TagAPI support to War

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -21,6 +21,10 @@
             <id>spout-repo</id>
             <url>http://repo.spout.org/</url>
         </repository>
+        <repository>
+            <id>tagapi-repo</id>
+            <url>http://repo.kitteh.org/content/repositories/public/</url>
+        </repository>
     </repositories>
   <issueManagement>
   	<system>Github issues</system>
@@ -75,6 +79,12 @@
     	<artifactId>bukkit</artifactId>
     	<version>1.4.5-R1.0</version>
     	<scope>compile</scope>
+    </dependency>
+    <dependency>
+	<groupId>org.kitteh</groupId>
+	<artifactId>tagapi</artifactId>
+	<version>2.0</version>
+	<scope>compile</scope>
     </dependency>
     <dependency>
     	<groupId>org.mockito</groupId>

--- a/war/src/main/java/com/tommytony/war/Team.java
+++ b/war/src/main/java/com/tommytony/war/Team.java
@@ -26,6 +26,7 @@ import com.tommytony.war.utility.Direction;
 import com.tommytony.war.utility.SignHelper;
 import com.tommytony.war.volume.BlockInfo;
 import com.tommytony.war.volume.Volume;
+import org.kitteh.tag.TagAPI;
 
 /**
  *
@@ -376,6 +377,9 @@ public class Team {
 
 	public void addPlayer(Player player) {
 		this.players.add(player);
+		if (War.war.isTagServer()) {
+			TagAPI.refreshPlayer(player);
+		}
 	}
 
 	public List<Player> getPlayers() {
@@ -450,7 +454,9 @@ public class Team {
 					t.teamcast("Cake " + ChatColor.GREEN + cake.getName() + ChatColor.WHITE  + " was returned.");
 				}
 			}
-						
+			if (War.war.isTagServer()) {
+				TagAPI.refreshPlayer(thePlayer);
+			}
 			return true;
 		}	
 		

--- a/war/src/main/java/com/tommytony/war/War.java
+++ b/war/src/main/java/com/tommytony/war/War.java
@@ -39,6 +39,7 @@ import com.tommytony.war.event.WarBlockListener;
 import com.tommytony.war.event.WarEntityListener;
 import com.tommytony.war.event.WarPlayerListener;
 import com.tommytony.war.event.WarServerListener;
+import com.tommytony.war.event.WarTagListener;
 import com.tommytony.war.job.HelmetProtectionTask;
 import com.tommytony.war.job.SpoutFadeOutMessageJob;
 import com.tommytony.war.mapper.WarYmlMapper;
@@ -73,6 +74,7 @@ public class War extends JavaPlugin {
 	private PluginDescriptionFile desc = null;
 	private boolean loaded = false;
 	private boolean isSpoutServer = false;
+	private boolean tagServer = false;
 
 	// Zones and hub
 	private List<Warzone> warzones = new ArrayList<Warzone>();
@@ -143,6 +145,15 @@ public class War extends JavaPlugin {
 		pm.registerEvents(this.entityListener, this);
 		pm.registerEvents(this.blockListener, this);
 		pm.registerEvents(this.serverListener, this);
+		if (pm.isPluginEnabled("TagAPI")) {
+			try {
+				Class.forName("org.kitteh.tag.TagAPI");
+				pm.registerEvents(new WarTagListener(), this);
+				this.tagServer = true;
+			} catch (ClassNotFoundException e) {
+				this.tagServer = false;
+			}
+		}
 
 		// Add defaults
 		warConfig.put(WarConfig.BUILDINZONESONLY, false);
@@ -1163,5 +1174,9 @@ public class War extends JavaPlugin {
 	
 	public HubLobbyMaterials getWarhubMaterials() {
 		return this.warhubMaterials;
+	}
+
+	public boolean isTagServer() {
+		return tagServer;
 	}
 }

--- a/war/src/main/java/com/tommytony/war/event/WarTagListener.java
+++ b/war/src/main/java/com/tommytony/war/event/WarTagListener.java
@@ -1,0 +1,19 @@
+package com.tommytony.war.event;
+
+import com.tommytony.war.Team;
+import org.bukkit.ChatColor;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.kitteh.tag.PlayerReceiveNameTagEvent;
+
+public class WarTagListener implements Listener {
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onNameTag(PlayerReceiveNameTagEvent event) {
+		Team team = Team.getTeamByPlayerName(event.getNamedPlayer().getName());
+		if (team != null) {
+			ChatColor teamColor = team.getKind().getColor();
+			event.setTag(teamColor + event.getNamedPlayer().getName());
+		}
+	}
+}

--- a/war/src/main/resources/plugin.yml
+++ b/war/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ description: Minecraft PVP arenas (called warzones) for a fast-paced and structu
 author: tommytony
 website: http://war.tommytony.com
 main: com.tommytony.war.War
-softdepend: [Spout]
+softdepend: [Spout, TagAPI]
 permissions:
   war.*:
     description: Full War permissions. Create and destroy warzones. Change War configuration.


### PR DESCRIPTION
Created from @columb's request in gh-604. It was quick and easy to set up and the output is nice. Player skins remain the same when viewed by other players. This is basically the old Spout based colored names, but for servers that don't want the load of it.
